### PR TITLE
공지사항 공백 상태로 수정 가능

### DIFF
--- a/src/pages/NoticePage.tsx
+++ b/src/pages/NoticePage.tsx
@@ -103,7 +103,7 @@ const NoticePage: React.FC = () => {
           <ModNoticeForm>
             <ModTextArea
               placeholder="수정할 내용을 입력하세요"
-              onChange={(e) => setNotice(e.target.value)}
+              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setNotice(e.target.value)}
               value={notice}
             />
 

--- a/src/pages/NoticePage.tsx
+++ b/src/pages/NoticePage.tsx
@@ -56,12 +56,7 @@ const NoticePage: React.FC = () => {
     });
   }, []);
 
-  const onModClick = async () => {
-    if (notice.trim() === '') {
-      showToast('내용을 채워주세요!', 'danger');
-      return;
-    }
-
+  const postNotice = async () => {
     try {
       await Api.put('/notice', {
         notice: notice.trim()
@@ -78,6 +73,13 @@ const NoticePage: React.FC = () => {
     }
   };
 
+  const onModClick = async () => {
+    if (notice.trim() === '') {
+      showToast('내용을 채워주세요!', 'danger');
+      return;
+    }
+    postNotice();
+  };
   return (
     <>
       <Helmet>

--- a/src/pages/NoticePage.tsx
+++ b/src/pages/NoticePage.tsx
@@ -96,8 +96,8 @@ const NoticePage: React.FC = () => {
       dangerMode: true
     }).then(async (confirm) => {
       if (confirm) {
-        await postNotice('reset');
         swal('공지사항이 초기화 되었습니다!', { icon: 'success' });
+        await postNotice('reset');
       }
     });
   };

--- a/src/pages/NoticePage.tsx
+++ b/src/pages/NoticePage.tsx
@@ -58,11 +58,11 @@ const NoticePage: React.FC = () => {
     });
   }, []);
 
-  const postNotice = async (type?: string) => {
-    if (type === 'reset') {
-      setNotice('');
+  const onModClick = async () => {
+    if (notice.trim() === '') {
+      showToast('내용을 채워주세요!', 'danger');
+      return;
     }
-
     try {
       await Api.put('/notice', {
         notice: notice.trim()
@@ -79,25 +79,29 @@ const NoticePage: React.FC = () => {
     }
   };
 
-  const onModClick = async () => {
-    if (notice.trim() === '') {
-      showToast('내용을 채워주세요!', 'danger');
-      return;
-    }
-    await postNotice();
-  };
-
-  const onResetClick = async () => {
+  const onResetClick = () => {
     swal({
       title: '정말 초기화 하시겠습니까?',
-      text: '( 공지사항의 내용이 모두 지워진 채로 저장됩니다. )',
+      text: '( 공지사항의 내용이 모두 지워진 채로 저장됩니다! )',
       icon: 'warning',
       buttons: ['취소', '확인'],
       dangerMode: true
     }).then(async (confirm) => {
       if (confirm) {
-        swal('공지사항이 초기화 되었습니다!', { icon: 'success' });
-        await postNotice('reset');
+        try {
+          await Api.put('/notice', {
+            notice: ''
+          });
+          showToast('성공적으로 공지사항이 초기화되었습니다!', 'success');
+        } catch (e) {
+          if (!e.response.data) return;
+          const { success, error } = e.response.data;
+          if (success || !error) return;
+
+          if (error === ErrorMessage.NO_PERMISSION) {
+            showToast('관리자만 접근 가능한 페이지입니다.', 'warning');
+          }
+        }
       }
     });
   };

--- a/src/pages/NoticePage.tsx
+++ b/src/pages/NoticePage.tsx
@@ -57,7 +57,11 @@ const NoticePage: React.FC = () => {
     });
   }, []);
 
-  const postNotice = async () => {
+  const postNotice = async (type?: string) => {
+    if (type === 'reset') {
+      setNotice('');
+    }
+
     try {
       await Api.put('/notice', {
         notice: notice.trim()
@@ -79,7 +83,7 @@ const NoticePage: React.FC = () => {
       showToast('내용을 채워주세요!', 'danger');
       return;
     }
-    postNotice();
+    await postNotice();
   };
 
   const onResetClick = async () => {
@@ -89,6 +93,9 @@ const NoticePage: React.FC = () => {
     }
     setNotice('');
     postNotice();
+    }).then(async (confirm) => {
+      if (confirm) {
+        await postNotice('reset');
   };
 
   return (

--- a/src/pages/NoticePage.tsx
+++ b/src/pages/NoticePage.tsx
@@ -10,7 +10,8 @@ import {
   MainSideBarContainer,
   MediumButton,
   SCREEN_SIZE,
-  showToast
+  showToast,
+  ButtonGroup
 } from 'sinamon-sikhye';
 import MainSideBar from '../components/MainSideBar';
 import Api from '../api';
@@ -80,6 +81,16 @@ const NoticePage: React.FC = () => {
     }
     postNotice();
   };
+
+  const onResetClick = async () => {
+    const msg = '정말 초기화 하시겠습니까? \n( 공지사항의 내용이 모두 지워진 채로 저장됩니다. )';
+    if (!window.confirm(msg)) {
+      return;
+    }
+    setNotice('');
+    postNotice();
+  };
+
   return (
     <>
       <Helmet>
@@ -111,7 +122,10 @@ const NoticePage: React.FC = () => {
 
             <BlankLine gap={10} />
 
-            <MediumButton onClick={onModClick}>수정하기</MediumButton>
+            <ButtonGroup>
+              <MediumButton onClick={onModClick}>수정하기</MediumButton>
+              <MediumButton onClick={onResetClick}>초기화</MediumButton>
+            </ButtonGroup>
           </ModNoticeForm>
 
           <BlankLine gap={20} />

--- a/src/pages/NoticePage.tsx
+++ b/src/pages/NoticePage.tsx
@@ -13,6 +13,7 @@ import {
   showToast,
   ButtonGroup
 } from 'sinamon-sikhye';
+import swal from 'sweetalert';
 import MainSideBar from '../components/MainSideBar';
 import Api from '../api';
 import NoticePreview from '../components/Notice/NoticePreview';
@@ -87,15 +88,18 @@ const NoticePage: React.FC = () => {
   };
 
   const onResetClick = async () => {
-    const msg = '정말 초기화 하시겠습니까? \n( 공지사항의 내용이 모두 지워진 채로 저장됩니다. )';
-    if (!window.confirm(msg)) {
-      return;
-    }
-    setNotice('');
-    postNotice();
+    swal({
+      title: '정말 초기화 하시겠습니까?',
+      text: '( 공지사항의 내용이 모두 지워진 채로 저장됩니다. )',
+      icon: 'warning',
+      buttons: ['취소', '확인'],
+      dangerMode: true
     }).then(async (confirm) => {
       if (confirm) {
         await postNotice('reset');
+        swal('공지사항이 초기화 되었습니다!', { icon: 'success' });
+      }
+    });
   };
 
   return (

--- a/src/pages/NoticePage.tsx
+++ b/src/pages/NoticePage.tsx
@@ -89,6 +89,7 @@ const NoticePage: React.FC = () => {
     }).then(async (confirm) => {
       if (confirm) {
         try {
+          setNotice('');
           await Api.put('/notice', {
             notice: ''
           });


### PR DESCRIPTION
## 😎 어떤 기능이 추가되거나 변경되었나요?
- 공지사항을 공백인 상태로 수정후 저장할 수 있게 하기 위해서 공지사항 초기화 기능을 새로 만들어 추가했습니다.

## ❗ 주의하거나 참고할 점이 있나요?
- showToast를 이용해서 초기화 재확인을 하려고 했는데 toast 종류중에는 confirm의 기능이 없어보여서 window.confirm()을 통해서 구현했습니다.
- 백엔드를 실행해놓은 상태로 테스트하지 못했습니다. 정상 작동이 되는지 확인이 필요합니다 