### PR TITLE
feat: 익명건의함 관리자 페이지 구현

### DIFF
--- a/src/components/Anonymous/AnonymousAddReplyModal.tsx
+++ b/src/components/Anonymous/AnonymousAddReplyModal.tsx
@@ -1,0 +1,69 @@
+import React, { Dispatch, SetStateAction, useState } from 'react';
+import { BlankLine, Heading2, MediumButton, Modal, SCREEN_SIZE, showToast } from 'sinamon-sikhye';
+import styled from 'styled-components';
+import swal from 'sweetalert';
+import Api from '../../api';
+
+interface Props {
+  readonly open: [boolean, Dispatch<SetStateAction<boolean>>];
+  readonly id: number;
+}
+
+const ReplyForm = styled.textarea`
+  width: 400px;
+  height: 300px;
+
+  font-family: 'Noto Sans KR', sans-serif;
+
+  padding: 1rem;
+
+  resize: none;
+
+  @media screen and (max-width: ${SCREEN_SIZE.SCREEN_MOBILE}) {
+    width: 200px;
+    height: 300px;
+  }
+`;
+
+const AnonymousAddReplyModal: React.FC<Props> = ({ id, open }) => {
+  const [content, setContent] = useState<string>('');
+
+  const onAddClick = async () => {
+    const confirm = await swal({
+      title: '정말로 등록할까요?',
+      icon: 'info',
+      buttons: ['아니오', '예']
+    });
+
+    if (!confirm) return;
+
+    await Api.post(`/anonymous/${id}/reply`, {
+      content
+    });
+
+    open[1](false);
+
+    showToast('답변이 등록되었습니다!', 'success');
+  };
+
+  return (
+    <Modal width={600} height={500} name="AnonyousModal" state={open}>
+      <Heading2>답변달기</Heading2>
+      <BlankLine gap={10} />
+
+      <ReplyForm
+        maxLength={400}
+        placeholder="최대 400자"
+        autoFocus
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+      />
+
+      <BlankLine gap={30} />
+
+      <MediumButton onClick={onAddClick}>등록</MediumButton>
+    </Modal>
+  );
+};
+
+export default AnonymousAddReplyModal;

--- a/src/components/Anonymous/AnonymousAddReplyModal.tsx
+++ b/src/components/Anonymous/AnonymousAddReplyModal.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction, useState } from 'react';
+import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import { BlankLine, Heading2, MediumButton, Modal, SCREEN_SIZE, showToast } from 'sinamon-sikhye';
 import styled from 'styled-components';
 import swal from 'sweetalert';
@@ -7,6 +7,7 @@ import Api from '../../api';
 interface Props {
   readonly open: [boolean, Dispatch<SetStateAction<boolean>>];
   readonly id: number;
+  readonly onSuccess: () => void;
 }
 
 const ReplyForm = styled.textarea`
@@ -25,8 +26,16 @@ const ReplyForm = styled.textarea`
   }
 `;
 
-const AnonymousAddReplyModal: React.FC<Props> = ({ id, open }) => {
+const AnonymousAddReplyModal: React.FC<Props> = ({ id, open, onSuccess }) => {
   const [content, setContent] = useState<string>('');
+
+  useEffect(() => setContent(''), [open]);
+
+  const onEnterKeyPress = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter') {
+      onAddClick();
+    }
+  };
 
   const onAddClick = async () => {
     const confirm = await swal({
@@ -44,6 +53,8 @@ const AnonymousAddReplyModal: React.FC<Props> = ({ id, open }) => {
     open[1](false);
 
     showToast('답변이 등록되었습니다!', 'success');
+
+    onSuccess();
   };
 
   return (
@@ -57,6 +68,7 @@ const AnonymousAddReplyModal: React.FC<Props> = ({ id, open }) => {
         autoFocus
         value={content}
         onChange={(e) => setContent(e.target.value)}
+        onKeyPress={onEnterKeyPress}
       />
 
       <BlankLine gap={30} />

--- a/src/components/Anonymous/AnonymousAddReplyModal.tsx
+++ b/src/components/Anonymous/AnonymousAddReplyModal.tsx
@@ -58,7 +58,7 @@ const AnonymousAddReplyModal: React.FC<Props> = ({ id, open, onSuccess }) => {
   };
 
   return (
-    <Modal width={600} height={500} name="AnonyousModal" state={open}>
+    <Modal width={600} height={500} name="AnonymousAddModal" state={open}>
       <Heading2>답변달기</Heading2>
       <BlankLine gap={10} />
 

--- a/src/components/Anonymous/AnonymousEditReplyModal.tsx
+++ b/src/components/Anonymous/AnonymousEditReplyModal.tsx
@@ -1,0 +1,89 @@
+import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import { BlankLine, Heading2, MediumButton, Modal, SCREEN_SIZE, showToast } from 'sinamon-sikhye';
+import styled from 'styled-components';
+import swal from 'sweetalert';
+import Api from '../../api';
+
+interface Props {
+  readonly open: [boolean, Dispatch<SetStateAction<boolean>>];
+  readonly replyId: number;
+  readonly onSuccess: () => void;
+}
+
+const ReplyForm = styled.textarea`
+  width: 400px;
+  height: 300px;
+
+  font-family: 'Noto Sans KR', sans-serif;
+
+  padding: 1rem;
+
+  resize: none;
+
+  @media screen and (max-width: ${SCREEN_SIZE.SCREEN_MOBILE}) {
+    width: 200px;
+    height: 300px;
+  }
+`;
+
+const AnonymousEditReplyModal: React.FC<Props> = ({ replyId, open, onSuccess }) => {
+  const [content, setContent] = useState<string>('');
+
+  useEffect(() => {
+    if (replyId === 0) return;
+
+    Api.get(`/anonymous/reply/${replyId}`).then((res) => {
+      if (res.data && res.data.success) {
+        setContent(res.data.data.content);
+      }
+    });
+  }, [replyId]);
+
+  const onEnterKeyPress = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter') {
+      onEditClick();
+    }
+  };
+
+  const onEditClick = async () => {
+    const confirm = await swal({
+      title: '정말로 수정할까요?',
+      icon: 'info',
+      buttons: ['아니오', '예']
+    });
+
+    if (!confirm) return;
+
+    await Api.put(`/anonymous/reply/${replyId}`, {
+      content
+    });
+
+    open[1](false);
+
+    showToast('답변이 수정되었습니다!', 'success');
+
+    onSuccess();
+  };
+
+  return (
+    <Modal width={600} height={500} name="AnonymousEditModal" state={open}>
+      <Heading2>답변수정</Heading2>
+      <BlankLine gap={10} />
+
+      <ReplyForm
+        maxLength={400}
+        placeholder="최대 400자"
+        autoFocus
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        onKeyPress={onEnterKeyPress}
+      />
+
+      <BlankLine gap={30} />
+
+      <MediumButton onClick={onEditClick}>수정</MediumButton>
+    </Modal>
+  );
+};
+
+export default AnonymousEditReplyModal;

--- a/src/components/Anonymous/AnonymousTable.tsx
+++ b/src/components/Anonymous/AnonymousTable.tsx
@@ -4,7 +4,7 @@ import { BodyItem, ButtonGroup, HeaderItem, SCREEN_SIZE, Table, TableHead } from
 import swal from 'sweetalert';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faComments, faEdit, faTrash } from '@fortawesome/free-solid-svg-icons';
-import { AnonymousReplyType, AnonymousType } from '../../types/Payload';
+import { AnonymousType } from '../../types/Payload';
 
 const ScrollContainer = styled.div`
   @media screen and (max-width: ${SCREEN_SIZE.SCREEN_TABLET}) {
@@ -50,7 +50,9 @@ const AnonymousTable: React.FC<TableProps> = ({
 }) => {
   const onContentClick = (content: string) => swal('익명건의 내용', content);
 
-  const ReplyButton = (id: number, content: string, reply: AnonymousReplyType[]) => {
+  const ReplyButton = (data: AnonymousType) => {
+    const { id, reply } = data;
+
     if (reply.length === 0) {
       return (
         <TableButton size="long" onClick={() => onAddReplyClick(id)}>
@@ -61,15 +63,15 @@ const AnonymousTable: React.FC<TableProps> = ({
 
     return (
       <ButtonGroup>
-        <TableButton size="small" onClick={() => swal('답변 내용', content)}>
+        <TableButton size="small" onClick={() => swal('답변 내용', reply[0].content)}>
           <FontAwesomeIcon icon={faComments} />
         </TableButton>
 
-        <TableButton size="small" onClick={() => onEditReplyClick(id)}>
+        <TableButton size="small" onClick={() => onEditReplyClick(reply[0].id)}>
           <FontAwesomeIcon icon={faEdit} />
         </TableButton>
 
-        <TableButton size="small" onClick={() => onDeleteReplyClick(id)}>
+        <TableButton size="small" onClick={() => onDeleteReplyClick(reply[0].id)}>
           <FontAwesomeIcon icon={faTrash} />
         </TableButton>
       </ButtonGroup>
@@ -100,7 +102,7 @@ const AnonymousTable: React.FC<TableProps> = ({
                       내용 보기
                     </TableButton>
                   </td>
-                  <td>{ReplyButton(item.id, item.reply[0].content, item.reply)}</td>
+                  <td>{ReplyButton(item)}</td>
                   <td>{new Date(item.createdAt).toLocaleDateString()}</td>
                 </BodyItem>
               );

--- a/src/components/Anonymous/AnonymousTable.tsx
+++ b/src/components/Anonymous/AnonymousTable.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import styled from 'styled-components';
+import { BodyItem, HeaderItem, SCREEN_SIZE, Table, TableHead } from 'sinamon-sikhye';
+import swal from 'sweetalert';
+import { AnonymousReplyType, AnonymousType } from '../../types/Payload';
+
+const ScrollContainer = styled.div`
+  @media screen and (max-width: ${SCREEN_SIZE.SCREEN_TABLET}) {
+    border-radius: 3px;
+    border: 1px solid var(--color-gray);
+  }
+
+  overflow-x: auto;
+`;
+
+const TableButton = styled.button`
+  width: 74px;
+  height: 32px;
+
+  border-radius: 3px;
+  border: 1px solid var(--color-gray);
+
+  background: white;
+  color: black;
+
+  cursor: pointer;
+
+  &:hover {
+    background-color: var(--color-button-hover);
+    color: white;
+  }
+`;
+
+interface TableProps {
+  readonly list: AnonymousType[];
+  readonly onAddReplyClick?: () => void;
+  readonly onShowReplyClick?: () => void;
+}
+
+const AnonymousTable: React.FC<TableProps> = ({ list, onAddReplyClick, onShowReplyClick }) => {
+  const onContentClick = (content: string) => swal('익명건의 내용', content);
+
+  const ReplyButton = (reply: AnonymousReplyType[]) => {
+    if (reply.length === 0) {
+      return <TableButton onClick={onAddReplyClick}>답변 달기</TableButton>;
+    }
+
+    return <TableButton onClick={onShowReplyClick}>답변 보기</TableButton>;
+  };
+
+  return (
+    <>
+      <ScrollContainer>
+        <Table>
+          <TableHead>
+            <tr>
+              <HeaderItem>#</HeaderItem>
+              <HeaderItem>제목</HeaderItem>
+              <HeaderItem>내용</HeaderItem>
+              <HeaderItem>답변</HeaderItem>
+              <HeaderItem>작성일</HeaderItem>
+            </tr>
+          </TableHead>
+          <tbody>
+            {list.map((item: AnonymousType) => {
+              return (
+                <BodyItem key={item.id}>
+                  <td>{item.id}</td>
+                  <td>{item.title}</td>
+                  <td>
+                    <TableButton onClick={() => onContentClick(item.content)}>
+                      내용 보기
+                    </TableButton>
+                  </td>
+                  <td>{() => ReplyButton(item.reply)}</td>
+                  <td>{new Date(item.createdAt).toLocaleDateString()}</td>
+                </BodyItem>
+              );
+            })}
+          </tbody>
+        </Table>
+      </ScrollContainer>
+    </>
+  );
+};
+
+export default AnonymousTable;

--- a/src/components/Anonymous/AnonymousTable.tsx
+++ b/src/components/Anonymous/AnonymousTable.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
-import { BodyItem, HeaderItem, SCREEN_SIZE, Table, TableHead } from 'sinamon-sikhye';
+import { BodyItem, ButtonGroup, HeaderItem, SCREEN_SIZE, Table, TableHead } from 'sinamon-sikhye';
 import swal from 'sweetalert';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faComments, faEdit, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { AnonymousReplyType, AnonymousType } from '../../types/Payload';
 
 const ScrollContainer = styled.div`
@@ -13,9 +15,9 @@ const ScrollContainer = styled.div`
   overflow-x: auto;
 `;
 
-const TableButton = styled.button`
-  width: 74px;
-  height: 32px;
+const TableButton = styled.button<{ size: 'small' | 'long' }>`
+  width: ${(props) => (props.size === 'small' ? '32px' : '74px')};
+  height: ${(props) => (props.size === 'small' ? '32px' : '32px')};
 
   border-radius: 3px;
   border: 1px solid var(--color-gray);
@@ -33,19 +35,45 @@ const TableButton = styled.button`
 
 interface TableProps {
   readonly list: AnonymousType[];
-  readonly onAddReplyClick?: () => void;
-  readonly onShowReplyClick?: () => void;
+  readonly onAddReplyClick: (id: number) => void;
+  readonly onShowReplyClick: (id: number) => void;
+  readonly onEditReplyClick: (id: number) => void;
+  readonly onDeleteReplyClick: (id: number) => void;
 }
 
-const AnonymousTable: React.FC<TableProps> = ({ list, onAddReplyClick, onShowReplyClick }) => {
+const AnonymousTable: React.FC<TableProps> = ({
+  list,
+  onAddReplyClick,
+  onShowReplyClick,
+  onEditReplyClick,
+  onDeleteReplyClick
+}) => {
   const onContentClick = (content: string) => swal('익명건의 내용', content);
 
-  const ReplyButton = (reply: AnonymousReplyType[]) => {
+  const ReplyButton = (id: number, content: string, reply: AnonymousReplyType[]) => {
     if (reply.length === 0) {
-      return <TableButton onClick={onAddReplyClick}>답변 달기</TableButton>;
+      return (
+        <TableButton size="long" onClick={() => onAddReplyClick(id)}>
+          답변 달기
+        </TableButton>
+      );
     }
 
-    return <TableButton onClick={onShowReplyClick}>답변 보기</TableButton>;
+    return (
+      <ButtonGroup>
+        <TableButton size="small" onClick={() => swal('답변 내용', content)}>
+          <FontAwesomeIcon icon={faComments} />
+        </TableButton>
+
+        <TableButton size="small" onClick={() => onEditReplyClick(id)}>
+          <FontAwesomeIcon icon={faEdit} />
+        </TableButton>
+
+        <TableButton size="small" onClick={() => onDeleteReplyClick(id)}>
+          <FontAwesomeIcon icon={faTrash} />
+        </TableButton>
+      </ButtonGroup>
+    );
   };
 
   return (
@@ -68,11 +96,11 @@ const AnonymousTable: React.FC<TableProps> = ({ list, onAddReplyClick, onShowRep
                   <td>{item.id}</td>
                   <td>{item.title}</td>
                   <td>
-                    <TableButton onClick={() => onContentClick(item.content)}>
+                    <TableButton size="long" onClick={() => onContentClick(item.content)}>
                       내용 보기
                     </TableButton>
                   </td>
-                  <td>{() => ReplyButton(item.reply)}</td>
+                  <td>{ReplyButton(item.id, item.reply[0].content, item.reply)}</td>
                   <td>{new Date(item.createdAt).toLocaleDateString()}</td>
                 </BodyItem>
               );

--- a/src/components/Anonymous/AnonymousTable.tsx
+++ b/src/components/Anonymous/AnonymousTable.tsx
@@ -35,27 +35,25 @@ const TableButton = styled.button<{ size: 'small' | 'long' }>`
 
 interface TableProps {
   readonly list: AnonymousType[];
-  readonly onAddReplyClick: (id: number) => void;
-  readonly onShowReplyClick: (id: number) => void;
-  readonly onEditReplyClick: (id: number) => void;
-  readonly onDeleteReplyClick: (id: number) => void;
+  readonly onAddReplyClick: (data: AnonymousType) => void;
+  readonly onEditReplyClick: (data: AnonymousType) => void;
+  readonly onDeleteReplyClick: (data: AnonymousType) => void;
 }
 
 const AnonymousTable: React.FC<TableProps> = ({
   list,
   onAddReplyClick,
-  onShowReplyClick,
   onEditReplyClick,
   onDeleteReplyClick
 }) => {
   const onContentClick = (content: string) => swal('익명건의 내용', content);
 
   const ReplyButton = (data: AnonymousType) => {
-    const { id, reply } = data;
+    const { reply } = data;
 
     if (reply.length === 0) {
       return (
-        <TableButton size="long" onClick={() => onAddReplyClick(id)}>
+        <TableButton size="long" onClick={() => onAddReplyClick(data)}>
           답변 달기
         </TableButton>
       );
@@ -67,11 +65,11 @@ const AnonymousTable: React.FC<TableProps> = ({
           <FontAwesomeIcon icon={faComments} />
         </TableButton>
 
-        <TableButton size="small" onClick={() => onEditReplyClick(reply[0].id)}>
+        <TableButton size="small" onClick={() => onEditReplyClick(data)}>
           <FontAwesomeIcon icon={faEdit} />
         </TableButton>
 
-        <TableButton size="small" onClick={() => onDeleteReplyClick(reply[0].id)}>
+        <TableButton size="small" onClick={() => onDeleteReplyClick(data)}>
           <FontAwesomeIcon icon={faTrash} />
         </TableButton>
       </ButtonGroup>

--- a/src/components/MainSideBar/index.tsx
+++ b/src/components/MainSideBar/index.tsx
@@ -5,6 +5,7 @@ import {
   faCalendarWeek,
   faKey,
   faSignOutAlt,
+  faStickyNote,
   faUmbrella,
   faUser
 } from '@fortawesome/free-solid-svg-icons';
@@ -102,6 +103,15 @@ const MainSideBar: React.FC = () => {
                 <FontAwesomeIcon icon={faBullhorn} />
               </SideBarIconWrapper>
               <p>공지사항 관리</p>
+            </MainSideBarItem>
+          </StyledLink>
+
+          <StyledLink to="/anonymous">
+            <MainSideBarItem>
+              <SideBarIconWrapper>
+                <FontAwesomeIcon icon={faStickyNote} />
+              </SideBarIconWrapper>
+              <p>익명건의함 관리</p>
             </MainSideBarItem>
           </StyledLink>
 

--- a/src/pages/AnonymousAdminPage.tsx
+++ b/src/pages/AnonymousAdminPage.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';
-import { BlankLine, Heading1, Heading3, MainSideBarContainer } from 'sinamon-sikhye';
+import { BlankLine, Heading1, Heading3, MainSideBarContainer, showToast } from 'sinamon-sikhye';
 import { Helmet } from 'react-helmet';
+import swal from 'sweetalert';
 import MainSideBar from '../components/MainSideBar';
 import { AnonymousType } from '../types/Payload';
 import Api from '../api';
@@ -19,15 +20,34 @@ const AnonymousAdminPage: React.FC = () => {
   const showReplyModalOpen = useState<boolean>(false);
   const [id, setId] = useState<number>(0);
 
-  useEffect(() => {
+  const fetchData = useCallback(() => {
     Api.get('/anonymous').then((res) => {
       if (res && res.data.success) setData(res.data.data);
     });
   }, []);
 
+  useEffect(() => fetchData(), [fetchData]);
+
   const onTableButtonClick = (func: (v: boolean) => void) => (i: number) => {
     setId(i);
     func(true);
+  };
+
+  const onDeleteClick = async (replyId: number) => {
+    const state = await swal({
+      title: '정말로 삭제하시겠습니까?',
+      text: '삭제 시 복구할 수 없습니다.',
+      icon: 'warning',
+      buttons: ['취소', '삭제'],
+      dangerMode: true
+    });
+
+    if (!state) return;
+
+    await Api.delete(`/anonymous/reply/${replyId}`);
+    showToast('답변이 삭제되었습니다.', 'success');
+
+    fetchData();
   };
 
   return (
@@ -50,7 +70,7 @@ const AnonymousAdminPage: React.FC = () => {
             onAddReplyClick={onTableButtonClick(addReplyModalOpen[1])}
             onShowReplyClick={onTableButtonClick(showReplyModalOpen[1])}
             onEditReplyClick={onTableButtonClick(showReplyModalOpen[1])}
-            onDeleteReplyClick={onTableButtonClick(showReplyModalOpen[1])}
+            onDeleteReplyClick={onDeleteClick}
           />
         </StyledContent>
       </MainSideBarContainer>

--- a/src/pages/AnonymousAdminPage.tsx
+++ b/src/pages/AnonymousAdminPage.tsx
@@ -75,7 +75,7 @@ const AnonymousAdminPage: React.FC = () => {
         </StyledContent>
       </MainSideBarContainer>
 
-      <AnonymousAddReplyModal id={id} open={addReplyModalOpen} />
+      <AnonymousAddReplyModal id={id} open={addReplyModalOpen} onSuccess={() => fetchData()} />
     </>
   );
 };

--- a/src/pages/AnonymousAdminPage.tsx
+++ b/src/pages/AnonymousAdminPage.tsx
@@ -8,6 +8,7 @@ import { AnonymousType } from '../types/Payload';
 import Api from '../api';
 import AnonymousTable from '../components/Anonymous/AnonymousTable';
 import AnonymousAddReplyModal from '../components/Anonymous/AnonymousAddReplyModal';
+import AnonymousEditReplyModal from '../components/Anonymous/AnonymousEditReplyModal';
 
 const StyledContent = styled.div`
   margin: 3rem;
@@ -17,8 +18,9 @@ const AnonymousAdminPage: React.FC = () => {
   const [data, setData] = useState<AnonymousType[]>([]);
 
   const addReplyModalOpen = useState<boolean>(false);
-  const showReplyModalOpen = useState<boolean>(false);
-  const [id, setId] = useState<number>(0);
+  const editReplyModalOpen = useState<boolean>(false);
+  const [focusAnonymousId, setFocusAnonymousId] = useState<number>(0);
+  const [focusReplyId, setFocusReplyId] = useState<number>(0);
 
   const fetchData = useCallback(() => {
     Api.get('/anonymous').then((res) => {
@@ -28,12 +30,17 @@ const AnonymousAdminPage: React.FC = () => {
 
   useEffect(() => fetchData(), [fetchData]);
 
-  const onTableButtonClick = (func: (v: boolean) => void) => (i: number) => {
-    setId(i);
-    func(true);
+  const onAddReplyClick = (anonymousData: AnonymousType) => {
+    setFocusAnonymousId(anonymousData.id);
+    addReplyModalOpen[1](true);
   };
 
-  const onDeleteClick = async (replyId: number) => {
+  const onEditReplyClick = (anonymousData: AnonymousType) => {
+    setFocusReplyId(anonymousData.reply[0].id);
+    editReplyModalOpen[1](true);
+  };
+
+  const onDeleteClick = async (anonymousData: AnonymousType) => {
     const state = await swal({
       title: '정말로 삭제하시겠습니까?',
       text: '삭제 시 복구할 수 없습니다.',
@@ -44,7 +51,7 @@ const AnonymousAdminPage: React.FC = () => {
 
     if (!state) return;
 
-    await Api.delete(`/anonymous/reply/${replyId}`);
+    await Api.delete(`/anonymous/reply/${anonymousData.reply[0].id}`);
     showToast('답변이 삭제되었습니다.', 'success');
 
     fetchData();
@@ -67,15 +74,23 @@ const AnonymousAdminPage: React.FC = () => {
 
           <AnonymousTable
             list={data}
-            onAddReplyClick={onTableButtonClick(addReplyModalOpen[1])}
-            onShowReplyClick={onTableButtonClick(showReplyModalOpen[1])}
-            onEditReplyClick={onTableButtonClick(showReplyModalOpen[1])}
+            onAddReplyClick={onAddReplyClick}
+            onEditReplyClick={onEditReplyClick}
             onDeleteReplyClick={onDeleteClick}
           />
         </StyledContent>
       </MainSideBarContainer>
 
-      <AnonymousAddReplyModal id={id} open={addReplyModalOpen} onSuccess={() => fetchData()} />
+      <AnonymousAddReplyModal
+        id={focusAnonymousId}
+        open={addReplyModalOpen}
+        onSuccess={() => fetchData()}
+      />
+      <AnonymousEditReplyModal
+        replyId={focusReplyId}
+        open={editReplyModalOpen}
+        onSuccess={() => fetchData()}
+      />
     </>
   );
 };

--- a/src/pages/AnonymousAdminPage.tsx
+++ b/src/pages/AnonymousAdminPage.tsx
@@ -1,14 +1,35 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { BlankLine, Heading1, Heading3, MainSideBarContainer } from 'sinamon-sikhye';
 import { Helmet } from 'react-helmet';
 import MainSideBar from '../components/MainSideBar';
+import { AnonymousType } from '../types/Payload';
+import Api from '../api';
+import AnonymousTable from '../components/Anonymous/AnonymousTable';
+import AnonymousAddReplyModal from '../components/Anonymous/AnonymousAddReplyModal';
 
 const StyledContent = styled.div`
   margin: 3rem;
 `;
 
 const AnonymousAdminPage: React.FC = () => {
+  const [data, setData] = useState<AnonymousType[]>([]);
+
+  const addReplyModalOpen = useState<boolean>(false);
+  const showReplyModalOpen = useState<boolean>(false);
+  const [id, setId] = useState<number>(0);
+
+  useEffect(() => {
+    Api.get('/anonymous').then((res) => {
+      if (res && res.data.success) setData(res.data.data);
+    });
+  }, []);
+
+  const onTableButtonClick = (func: (v: boolean) => void) => (i: number) => {
+    setId(i);
+    func(true);
+  };
+
   return (
     <>
       <Helmet>
@@ -21,11 +42,20 @@ const AnonymousAdminPage: React.FC = () => {
         <StyledContent>
           <Heading1>익명건의함 관리</Heading1>
           <Heading3>익명건의를 관리하고 답변을 달 수 있습니다.</Heading3>
+
           <BlankLine gap={30} />
 
-          <BlankLine gap={10} />
+          <AnonymousTable
+            list={data}
+            onAddReplyClick={onTableButtonClick(addReplyModalOpen[1])}
+            onShowReplyClick={onTableButtonClick(showReplyModalOpen[1])}
+            onEditReplyClick={onTableButtonClick(showReplyModalOpen[1])}
+            onDeleteReplyClick={onTableButtonClick(showReplyModalOpen[1])}
+          />
         </StyledContent>
       </MainSideBarContainer>
+
+      <AnonymousAddReplyModal id={id} open={addReplyModalOpen} />
     </>
   );
 };

--- a/src/pages/AnonymousAdminPage.tsx
+++ b/src/pages/AnonymousAdminPage.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import styled from 'styled-components';
+import { BlankLine, Heading1, Heading3, MainSideBarContainer } from 'sinamon-sikhye';
+import { Helmet } from 'react-helmet';
+import MainSideBar from '../components/MainSideBar';
+
+const StyledContent = styled.div`
+  margin: 3rem;
+`;
+
+const AnonymousAdminPage: React.FC = () => {
+  return (
+    <>
+      <Helmet>
+        <title>익명건의함 관리 - 수정과 관리자</title>
+      </Helmet>
+
+      <MainSideBarContainer>
+        <MainSideBar />
+
+        <StyledContent>
+          <Heading1>익명건의함 관리</Heading1>
+          <Heading3>익명건의를 관리하고 답변을 달 수 있습니다.</Heading3>
+          <BlankLine gap={30} />
+
+          <BlankLine gap={10} />
+        </StyledContent>
+      </MainSideBarContainer>
+    </>
+  );
+};
+
+export default AnonymousAdminPage;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -10,6 +10,7 @@ import CodePage from './pages/CodePage';
 import UserPage from './pages/UserPage';
 import TimetablePage from './pages/TimetablePage';
 import NoticePage from './pages/NoticePage';
+import AnonymousAdminPage from './pages/AnonymousAdminPage';
 
 const Router: React.FC = () => {
   return (
@@ -61,6 +62,13 @@ const Router: React.FC = () => {
           exact
           path="/notice"
           success={NoticePage}
+          failure={PermissionPage}
+          permissions={['admin', 'teacher', 'schoolunion']}
+        />
+        <PermissionRoute
+          exact
+          path="/anonymous"
+          success={AnonymousAdminPage}
           failure={PermissionPage}
           permissions={['admin', 'teacher', 'schoolunion']}
         />

--- a/src/types/Payload.ts
+++ b/src/types/Payload.ts
@@ -44,3 +44,21 @@ export interface SubjectType {
   readonly teacher: string;
   readonly url: string;
 }
+
+export interface AnonymousType {
+  readonly id: number;
+  readonly title: string;
+  readonly content: string;
+  readonly reply: AnonymousReplyType[];
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+}
+
+interface AnonymousReplyType {
+  readonly id: string;
+  readonly content: string;
+  readonly author: string;
+  readonly user: ProfileType;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+}

--- a/src/types/Payload.ts
+++ b/src/types/Payload.ts
@@ -54,7 +54,7 @@ export interface AnonymousType {
   readonly updatedAt: Date;
 }
 
-interface AnonymousReplyType {
+export interface AnonymousReplyType {
   readonly id: string;
   readonly content: string;
   readonly author: string;

--- a/src/types/Payload.ts
+++ b/src/types/Payload.ts
@@ -55,7 +55,7 @@ export interface AnonymousType {
 }
 
 export interface AnonymousReplyType {
-  readonly id: string;
+  readonly id: number;
   readonly content: string;
   readonly author: string;
   readonly user: ProfileType;


### PR DESCRIPTION
## 😎 어떤 기능이 추가되거나 변경되었나요?
- 익명건의함 관리자 페이지를 구현하였습니다.
- 모달을 통해 건의 내용, 답변 내용을 확인할 수 있습니다.
- 답변이 없을 경우 답변을 등록할 수 있습니다.

## ❗ 주의하거나 참고할 점이 있나요?
- API 스펙상 여러개의 답변을 달 수 있으나 현재는 한 개의 답변만 달 수 있도록 하였습니다.